### PR TITLE
Aioredis format for initialization

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,12 @@ Create Redis instance using ``testing.redis.RedisServer``::
 
   # Redis server is terminated here
 
+The aioredis (async redis) supposes difference format of param for initialization ::
+
+  ...
+  r = await aioredis.create_redis(redis_server.url)
+  ...
+
 
 ``testing.redis`` automatically searchs for redis-server from ``$PATH``.
 If you install redis to other directory, set ``redis_server`` keyword::

--- a/src/testing/redis.py
+++ b/src/testing/redis.py
@@ -55,6 +55,10 @@ class RedisServer(Database):
 
         return params
 
+    @property
+    def url(self):
+        return "redis://{host}:{port}".format(**self.dsn())
+
     def get_data_directory(self):
         return os.path.join(self.base_dir, 'data')
 

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -23,6 +23,7 @@ class TestRedisServer(unittest.TestCase):
         self.assertIsNotNone(redis)
         self.assertEqual(redis.dsn(),
                          dict(host='127.0.0.1', port=redis.redis_conf['port'], db=0))
+        self.assertEqual(redis.url, 'redis://127.0.0.1:{port}'.format(port=redis.redis_conf['port']))
 
         # connect to redis
         r = Redis(**redis.dsn())


### PR DESCRIPTION
The aioredis supposes difference format for creating connection:
```
import aioredis
r = await aioredis.create_redis('redis://localhost:6379')
```

